### PR TITLE
Try local storagefor shopping list

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -8,7 +8,7 @@ import { Component } from '@angular/core';
 export class AppComponent {
   title = 'cooking-app';
 
-  loadedFearute = 'recipe';
+  loadedFearute = 'shopping-list';
 
   onNavigate(feature: string) {
     // console.log(feature)

--- a/src/app/shopping-list/shopping-list.component.ts
+++ b/src/app/shopping-list/shopping-list.component.ts
@@ -14,7 +14,7 @@ export class ShoppingListComponent implements OnInit {
     JSON.parse(localStorage.getItem('ingredients')) || []
    ;
 
-  ingredientsLocal =  JSON.parse(localStorage.getItem('ingredients'));
+  ingredientsLocal = null;
 
   constructor() {}
 

--- a/src/app/shopping-list/shopping-list.component.ts
+++ b/src/app/shopping-list/shopping-list.component.ts
@@ -8,13 +8,13 @@ import { Ingredient } from '../shared/ingredient.model';
 })
 export class ShoppingListComponent implements OnInit {
   ingriedients: any[] =  
-    // [new Ingredient('Apples', 5, 'pieces'),
+    // new Ingredient('Apples', 5, 'pieces'),
     // new Ingredient('Carrots', 2, 'pieces'),
     // new Ingredient('Tofu', 1, 'kg'),]
-    JSON.parse(localStorage.getItem('ingredients'))
+    JSON.parse(localStorage.getItem('ingredients')) || []
    ;
 
-  ingredientsLocal = [];
+  ingredientsLocal =  JSON.parse(localStorage.getItem('ingredients'));
 
   constructor() {}
 
@@ -24,15 +24,16 @@ export class ShoppingListComponent implements OnInit {
    
     // this.ingriedients.push(ingredient);
     // console.log(ingredient)
-    if (this.ingredientsLocal = null) {
+    if (this.ingredientsLocal === null  ) {
       console.log('1' + this.ingredientsLocal);
-      // ingredientsLocal = [];
+      this.ingredientsLocal = [];
     } else {
       this.ingredientsLocal = JSON.parse(localStorage.getItem('ingredients'));
       console.log('2' + this.ingredientsLocal);
      
     }
-      // this.ingriedients.push(ingredient);
+      this.ingriedients.push(ingredient);
+      console.log("log ingredients" + this.ingriedients);
       this.ingredientsLocal.push({name: ingredient.name, amount: ingredient.amount, unit: ingredient.unit});
       localStorage.setItem('ingredients', JSON.stringify(this.ingredientsLocal));
       console.log('last log of ingredientsLocal');


### PR DESCRIPTION
when I deleted  manually the Local Storage item I realised that script doesn't work anymore, 
 if there was already 'ingredients' in LocalStorage it was fine
the was a problem with if (this.ingredientsLocal === null  ) check
so ,
**In case   ingredientsLocal; is not defined it gives problems, the first entered item doesn't get pushed into the** **ingredientsLocal properly (picture 1) I am still not sure why?????,** 
`I tried setting it to  ingredientsLocal = []; `
, did not help

then I set it to:
`ingredientsLocal =  JSON.parse(localStorage.getItem('ingredients'));`
and then it works

and THEN I had finally had (hopefully correct idea) to set it to: 
`ingredientsLocal = null;`
... yes

Now even if I manually delete the LocalStorage 'ingredients' everything works fine, after adding first ingredient they get stored and displayed properly

PICTURE 1
<img width="2462" alt="Screenshot 2022-10-05 at 13 04 14" src="https://user-images.githubusercontent.com/89396456/194047158-718f8140-dd3d-4698-b9eb-a4151b8e44ab.png">
